### PR TITLE
Add Waveshare RP2040-Zero board support

### DIFF
--- a/.github/workflows/build-rp2040.yml
+++ b/.github/workflows/build-rp2040.yml
@@ -50,6 +50,11 @@ jobs:
           PICO_BOARD=waveshare_rp2040_pizero cmake ..
           make remapper
           cd ..
+          mkdir build-waveshare_rp2040_zero
+          cd build-waveshare_rp2040_zero
+          PICO_BOARD=waveshare_rp2040_zero cmake ..
+          make remapper
+          cd ..
           mkdir build-pico2
           cd build-pico2
           PICO_BOARD=pico2 cmake ..
@@ -77,6 +82,7 @@ jobs:
           mv build-board_v8/remapper.uf2 artifacts/remapper_board_v8.uf2
           mv build-feather/remapper.uf2 artifacts/remapper_feather.uf2
           mv build-waveshare_rp2040_pizero/remapper.uf2 artifacts/remapper_waveshare_rp2040_pizero.uf2
+          mv build-waveshare_rp2040_pizero/remapper.uf2 artifacts/remapper_waveshare_rp2040_zero.uf2
           mv build-pico2/remapper.uf2 artifacts/remapper_pico2.uf2
           mv build-pico2/remapper_dual_a.uf2 artifacts/remapper_pico2_dual_a.uf2
           mv build-pico2/remapper_dual_b.uf2 artifacts/remapper_pico2_dual_b.uf2

--- a/firmware/src/boards/waveshare_rp2040_zero.h
+++ b/firmware/src/boards/waveshare_rp2040_zero.h
@@ -1,0 +1,50 @@
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+#ifndef _BOARDS_WAVESHARE_RP2040_ZERO_H
+#define _BOARDS_WAVESHARE_RP2040_ZERO_H
+
+#define WAVESHARE_RP2040_ZERO_BOARD
+
+#define GPIO_VALID_PINS_BASE 0b00000000001111110000111111111111
+
+#define PICO_DEFAULT_PIO_USB_DP_PIN 0
+
+//------------- LED --------------//
+
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 16
+#endif
+
+//------------- UART -------------//
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 1
+#endif
+
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 8
+#endif
+
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 9
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (1 * 1024 * 1024)
+#endif
+
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 1
+#endif
+
+#endif


### PR DESCRIPTION
**Added [Waveshare RP2040-Zero](https://www.waveshare.com/wiki/RP2040-Zero) board definitions and build actions.**

When using the default remapper.uf2 in an RP2040-Zero board, it will activate the WS2812 RGB LED PIN to its brightest and keeps it activated as long as the board is activated. Risking the LED durability. Because the default TX or RX pins in the build config set to the same GP16 that used for the LED. 

This commit:
 - Added additional definition and build definition specific to the board
 - Moved the UART to UART 1 in pin 8 and 9 for this specific board config.
 - DP set to pin 0 and DM to pin 1 in the config
 - Added definition to the LED Pin (16) in the config